### PR TITLE
Remove scp alias

### DIFF
--- a/conf/.bashrc
+++ b/conf/.bashrc
@@ -128,7 +128,6 @@ alias rmd='rm -r'
 alias srm='sudo rm'
 alias srmd='sudo rm -r'
 alias cpd='cp -R'
-alias scp='sudo cp'
 alias scpd='sudo cp -R'
 
 #nano

--- a/conf/.zshrc
+++ b/conf/.zshrc
@@ -213,7 +213,6 @@ alias rmd='rm -r'
 alias srm='sudo rm'
 alias srmd='sudo rm -r'
 alias cpd='cp -R'
-alias scp='sudo cp'
 alias scpd='sudo cp -R'
 
 #nano


### PR DESCRIPTION
`scp` is an alias for `sudo cp` but it is also a package in [openssh](https://wiki.archlinux.org/title/SCP_and_SFTP). It very annoying to find this out while needing scp in a urgent situation.